### PR TITLE
support getting manual logs by user

### DIFF
--- a/LivingLab.Core/Constants/DummyUser.cs
+++ b/LivingLab.Core/Constants/DummyUser.cs
@@ -1,0 +1,10 @@
+using LivingLab.Core.Entities.Identity;
+
+public static class DummyUser
+{
+    public static readonly ApplicationUser INSTANCE = new ApplicationUser() {
+        FirstName = "Carlos",
+        LastName = "Eggsampler",
+        UserName = "PepsiLover69"
+    };
+}

--- a/LivingLab.Core/Interfaces/Repositories/IEnergyUsageRepository.cs
+++ b/LivingLab.Core/Interfaces/Repositories/IEnergyUsageRepository.cs
@@ -1,4 +1,5 @@
 using LivingLab.Core.Entities;
+using LivingLab.Core.Entities.Identity;
 
 namespace LivingLab.Core.Interfaces.Repositories;
 
@@ -7,5 +8,9 @@ public interface IEnergyUsageRepository : IRepository<EnergyUsageLog>
     Task<List<EnergyUsageLog>> GetUsageByDeviceId(int id);
     Task<List<EnergyUsageLog>> GetUsageByDeviceType(string deviceType);
     Task<List<EnergyUsageLog>> GetUsageByLabId(int id);
+    /// <summary>Retrives all logs manually uploaded by user with userId</summary>
+    /// <remarks>if userId is null, retrieves logs manually uploaded by any user</remarks>
+    Task<List<EnergyUsageLog>> GetUsageByUser(ApplicationUser? user);
     Task BulkInsertAsync(ICollection<EnergyUsageLog> logs);
+    Task BulkInsertAsyncByUser(ICollection<EnergyUsageLog> logs, ApplicationUser loggedBy);
 }

--- a/LivingLab.Web/Controllers/ManualLogsController.cs
+++ b/LivingLab.Web/Controllers/ManualLogsController.cs
@@ -69,7 +69,8 @@ public class ManualLogsController : Controller
         try
         {
             var data = _mapper.Map<List<LogItemViewModel>, List<EnergyUsageLog>>(logs);
-            var loggedUser = await _userManager.GetUserAsync(User);
+            // var loggedUser = await _userManager.GetUserAsync(User);
+            var loggedUser = DummyUser.INSTANCE;
             await _repository.BulkInsertAsyncByUser(data, loggedUser);
 
             return Ok();


### PR DESCRIPTION
resolves #75 

Note: until user accounts are tracked, all manually uploaded logs are tagged with null user (not logged in), so get logs by user will return empty list.

Edit: temporarily use dummy user to generate a fake user and then use its foreign key